### PR TITLE
more meaningfull exception

### DIFF
--- a/flask_flatpages/__init__.py
+++ b/flask_flatpages/__init__.py
@@ -86,7 +86,9 @@ class Page(object):
         #     yaml.safe_load('- 1\n- a') -> [1, 'a']
         if not meta:
             return {}
-        assert isinstance(meta, dict)
+        if not isinstance(meta, dict):
+            raise Exception("Excpecting a valid dict in meta <%(_meta_yaml)s> for page at <%(path)s>" % 
+                self.__dict__)        
         return meta
 
     def __getitem__(self, name):


### PR DESCRIPTION
While I tried this module I wrote 

```
    key:"value"
```

Which is a meaningfull yaml string while a meaningful dict is ecxpected in the form

```
key: "value"
```

I propose to raise an exception instead of an assert
