### PR TITLE
support for different renderer function depending on file extension.

### DIFF
--- a/flask_flatpages/pages/multi_renderer.json
+++ b/flask_flatpages/pages/multi_renderer.json
@@ -1,0 +1,12 @@
+title: json
+
+{
+    "id": 1,
+    "name": "Foo",
+    "price": 123,
+    "tags": [ "Bar", "Eek" ],
+    "stock": {
+        "warehouse": 300,
+        "retail": 20
+    }
+}


### PR DESCRIPTION
fuses `FLATPAGES_EXTENSION` and `FLATPAGES_HTML_RENDERER` into a
`FLATPAGES_EXTENSION_RENDERER` dictionary of the form `{'extension': renderer}`

(Related to https://github.com/SimonSapin/Flask-FlatPages/pull/10 )

I belive that intsead of defining a renderer per page, it will be far more useful to define it per extension. Becuase it woudn't make sense to use a renderer function only for one page.

I think that if implemented on a per page basis one would just end up defining the same renderer on many files. It makes more sense to do define it for many files based on extension

I'm willing to update the documentation if necessary.
