### PR TITLE
Add 'headerid' markdown extension.

### DIFF
--- a/flask_flatpages/__init__.py
+++ b/flask_flatpages/__init__.py
@@ -36,7 +36,7 @@ def pygmented_markdown(text):
     except ImportError:
         extensions = []
     else:
-        extensions = ['codehilite', 'headerid']
+        extensions = ['codehilite(guess_lang=False)', 'headerid']
     return markdown.markdown(text, extensions)
 
 


### PR DESCRIPTION
Just a simple addition to the extension list for rendering markdown.

Currently, it's impossible to link to a URL of the form `http://some-site.com/whatever#relevant_header`, unless you use raw HTML in your markdown to specify the id attribute. This is very messy in the context of a markdown document.

The extension is not intrusive and shouldn't mess up anything for anyone. The default algorithm for generating ids is to slugify the header text, so `Cool Header Text` becomes `cool-header-text`.
