### PR TITLE
added ability to register a function that will add extra information to ...

### DIFF
--- a/flask_flatpages/pages/2012-08-09-foo-bar.html
+++ b/flask_flatpages/pages/2012-08-09-foo-bar.html
@@ -1,0 +1,7 @@
+title: Foo > bar
+created: 2010-12-11
+versions:
+    - 3.14
+    - 42
+
+Foo *bar*


### PR DESCRIPTION
...page meta

It would be nice to be able to register a function with Flask-Flatpages that adds information to the Page Metadata. This function will parse information out of some meaningful file name. 

Providing a means to register a function allows the developer to choose what type of file naming convention best suits there project (or none at all).

Several static site generators use naming conventions and it is a handy feature in my mind. When you have a lot of posts in one directory, naming conventions can give you a predictable time based order when sorted by characters.

I am trying to port my blog efforts from a static site generator that uses this type of naming convention methodology and I do not want to have to port the date information in the naming convention into the yaml metadata. 

This method is an idea for allowing users of Flask-Flatpages to easily adapt naming convention information into the page meta. 
