### PR TITLE
added load_subs function

### DIFF
--- a/flask_flatpages/__init__.py
+++ b/flask_flatpages/__init__.py
@@ -264,6 +264,24 @@ class FlatPages(object):
             self._file_cache[filename] = page, mtime
         return page
 
+    def load_subs(self, path):
+        """Load all files (recursively) in a sub-directory.
+            :path: is a relative path from inside ``FLATPAGES_ROOT``.
+        """
+        subs = []
+        extension = self.config('extension') 
+        subdir = os.path.join(self.root, path)
+    
+        for name in os.listdir(subdir):
+            full_name = os.path.join(subdir, name)    
+            if os.path.isdir(full_name):            
+                self.load_subs(full_name)
+            else:
+                no_ext = full_name[:-len(extension)]
+                page = self._load_file(no_ext, full_name)
+                subs.append(page)
+        return subs
+
     @werkzeug.cached_property
     def _pages(self):
         """Walk the page root directory an return a dict of unicode path:


### PR DESCRIPTION
This enables you to load the files from other sub-directories in the FlatPages Root by specifying a relative path into `load_subs`. It seems to behave like the `pages` variable often set like this `pages = FlatPages(Flask(__name__))`.
