### PR TITLE
Implement Flask flag to allow pages marked as draft to be hidden

### DIFF
--- a/flask_flatpages/flatpages.py
+++ b/flask_flatpages/flatpages.py
@@ -33,6 +33,7 @@ class FlatPages(object):
         ('html_renderer', pygmented_markdown),
         ('markdown_extensions', ['codehilite']),
         ('auto_reload', 'if debug'),
+        ('hide_drafts', False),
     )
 
     def __init__(self, app=None, name=None):

--- a/flask_flatpages/flatpages.py
+++ b/flask_flatpages/flatpages.py
@@ -227,8 +227,19 @@ class FlatPages(object):
                 format(type(extension).__name__, extension)
             )
 
-        return dict([(path, self._load_file(path, full_name))
-                     for path, full_name in _walker()])
+        pages = dict()
+
+        for path, full_name in _walker():
+            page = self._load_file(path, full_name)
+
+            # if user is hiding drafts, then don't return pages marked as draft
+            if self.app.config['FLATPAGES_HIDE_DRAFTS'] \
+                    and page.meta.get('draft'):
+                pass  # do not include this page
+            else:
+                pages.update([(path, page)])
+
+        return pages
 
     def _parse(self, content, path):
         """Parse a flatpage file, i.e. read and parse its meta data and body.

--- a/tests/pages/draft.html
+++ b/tests/pages/draft.html
@@ -1,0 +1,6 @@
+draft: True
+title: Draft exclusion config
+template: draft.html
+
+Files should be ignored as long as FLATPAGES_HIDE_DRAFTS is True in the
+main application, and any template contains `draft: False`.

--- a/tests/test_flask_flatpages.py
+++ b/tests/test_flask_flatpages.py
@@ -153,6 +153,7 @@ class TestFlatPages(unittest.TestCase):
         self.assertEqual(
             set(page.path for page in pages),
             set(['codehilite',
+                 'draft',
                  'extra',
                  'foo',
                  'foo/42/not_a_page',
@@ -186,6 +187,7 @@ class TestFlatPages(unittest.TestCase):
         self.assertEqual(
             set(page.path for page in pages),
             set(['codehilite',
+                 'draft',
                  'extra',
                  'foo',
                  'foo/bar',
@@ -355,6 +357,7 @@ class TestFlatPages(unittest.TestCase):
             self.assertEqual(
                 set(page.path for page in pages),
                 set(['codehilite',
+                     'draft',
                      'extra',
                      'foo',
                      'foo/bar',
@@ -371,6 +374,7 @@ class TestFlatPages(unittest.TestCase):
             self.assertEqual(
                 set(safe_unicode(page.path for page in pages)),
                 set(['codehilite',
+                     'draft',
                      'extra',
                      'foo',
                      'foo/bar',
@@ -397,3 +401,12 @@ class TestFlatPages(unittest.TestCase):
                          datetime.datetime(2015, 2, 9, 10, 59, 0))
         self.assertEqual(foo['versions'], [3.14, 42])
         self.assertRaises(KeyError, lambda: foo['nonexistent'])
+
+    def test_draft_exclusion(self):
+        app = Flask(__name__)
+        app.config['FLATPAGES_HIDE_DRAFTS'] = True
+        pages = FlatPages(app)
+        self.assertEqual(
+            set(page.path for page in pages),
+            set([u'foo/lorem/ipsum', u'toc', u'foo/bar', u'hello', u'foo', u'headerid', u'extra', u'codehilite'])
+        )


### PR DESCRIPTION
FlatPages is doing almost everything that I need. This wasn't the most important thing on my list, but it was an annoyance because I'd have to constantly be moving files in and out of the `pages` directory.

I've done PRs loads of times but this is my first time committing to a package repo so I'm not sure of the process. I know I'll need to update the docs to include this flag, and the optional meta property in pages. I wanted to get input on this first

1) Is this even desired.
2) Is my syntax and approach acceptable
3) Tests. I'd like to add a test for this, but I've only ever run tests from within the context of a Django application. Guidance on how to configure my local repo to let me run tests would be appreciated.
