### PR TITLE
Update documentation for jinja prerender

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -207,6 +207,9 @@ Pre-rendering Markdown flatpages with Jinja
     def my_renderer(text):
         prerendered_body = render_template_string(text)
         return pygmented_markdown(prerendered_body)
+        # Or, if you wish to render using the markdown extensions
+        # listed in FLATPAGES_MARKDOWN_EXTENSIONS:
+        #return pygmented_markdown(prerendered_body, flatpages=pages)
 
     app = Flask(__name__)
     app.config['FLATPAGES_HTML_RENDERER'] = my_renderer


### PR DESCRIPTION
Hi there!

I needed to use a jinja2 pre-render before rendering my markdown documents. I followed the [documentation best practice](http://flask-flatpages.readthedocs.io/en/latest/) on this, but was running into problems getting my markdown extensions to apply correctly - namely my markdown code snippets weren't being rendered properly.

---

Here is an example of what I mean. The python code snippet near the bottom wasn't rendered.
![2016-08-26-132337_1114x1080_scrot](https://cloud.githubusercontent.com/assets/2654835/18021531/d7c25a0c-6b9c-11e6-8031-e5839ffd6fac.png)

After fixing my problem (an extra parameter to the `pygmented_markdown` function), I figured that others running into the same problem would benefit from documentation that explains how to use a custom html renderer that also uses your markdown extensions.

---

This is the same example as above, but with the fix in place. The code snippet renders properly.
![2016-08-26-133342_967x1057_scrot](https://cloud.githubusercontent.com/assets/2654835/18021559/0cd61f30-6b9d-11e6-8ed0-d3532c985e59.png)

[For reference, this is the code I tested on.](https://github.com/brookskindle/scraps/tree/610d6a1faf18a0a631aae36d9c73d2ba30ff97ed/python/flask/flatpages/prerender_jinja) It was meant to be modeled after the documentation.

---

Let me know if you think I've missed anything!
