### PR TITLE
Update Tests to use Flask 1.0, latest versions of dependencies

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,10 @@
 /dist
 /docs/_build
 /.tox
+Pipfile
+Pipfile.lock
 
 env*
 .coverage
+
+.DS_Store

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,24 +1,15 @@
 language: python
 env:
-  - TOXENV=py26-flask08
-  - TOXENV=py26-flask09
-  - TOXENV=py26-flask010
-  - TOXENV=py27-flask08
-  - TOXENV=py27-flask09
-  - TOXENV=py27-flask010
-  - TOXENV=py33-flask010
-  - TOXENV=py34-flask010
-  - TOXENV=pypy-flask08
-  - TOXENV=pypy-flask09
-  - TOXENV=pypy-flask010
+  - TOXENV=py27-flask10
+  - TOXENV=py27-flask102
+  - TOXENV=py34-flask10
+  - TOXENV=py34-flask102
+  - TOXENV=py35-flask10
+  - TOXENV=py35-flask102
+  - TOXENV=py36-flask10
+  - TOXENV=py36-flask102
 
 install:
-  - pip install tox==1.9.2
+  - pip install tox>=3.3.0
 script:
   - tox
-
-matrix:
-  allow_failures:
-    - env: TOXENV=pypy-flask08
-    - env: TOXENV=pypy-flask09
-    - env: TOXENV=pypy-flask010

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,10 +1,12 @@
-sudo: false
+sudo: true
+dist: xenial
 language: python
 python:
   - "2.7"
   - "3.4"
   - "3.5"
   - "3.6"
+  - "3.7"
 
 install:
   - pip install tox-travis==0.10

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,15 +1,10 @@
 language: python
-env:
-  - TOXENV=py27-flask10
-  - TOXENV=py27-flask102
-  - TOXENV=py34-flask10
-  - TOXENV=py34-flask102
-  - TOXENV=py35-flask10
-  - TOXENV=py35-flask102
-  - TOXENV=py36-flask10
-  - TOXENV=py36-flask102
+  - "2.7"
+  - "3.4"
+  - "3.5"
+  - "3.6"
 
 install:
-  - pip install tox>=3.3.0
+  - pip install tox-travis
 script:
   - tox

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,10 +1,12 @@
+sudo: false
 language: python
+python:
   - "2.7"
   - "3.4"
   - "3.5"
   - "3.6"
 
 install:
-  - pip install tox-travis
+  - pip install tox-travis==0.10
 script:
   - tox

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -4,7 +4,7 @@ Flask-FlatPages
 Flask-FlatPages provides a collection of pages to your `Flask`_ application.
 Pages are built from “flat” text files as opposed to a relational database.
 
-* Works on Python 2.6, 2.7 and 3.3+
+* Works on Python 2.7 and 3.4+
 * BSD licensed
 * Latest documentation `on Read the Docs`_
 * Source, issues and pull requests `on Github`_
@@ -101,8 +101,8 @@ are optional.
     using footnotes extension, use next syntax:
     ``['footnotes(UNIQUE_IDS=True)']``.
 
-    To disable line numbers in CodeHilite extension, which are enabled by
-    default, use: ``['codehilite(linenums=False)']``
+    To enable line numbers in CodeHilite extension, which are disabled by
+    default, use: ``['codehilite(linenums=True)']``
 
 ``FLATPAGES_AUTO_RELOAD``
     Wether to reload pages at each request. See :ref:`laziness-and-caching`
@@ -325,6 +325,12 @@ API
 
 Changelog
 ---------
+
+Vesrion 0.6.1
+~~~~~~~~~~~~~
+
+* Update dependencies to `Flask>=1.0` (as Flask 0.12.1 has known vulnerabilities).
+* Pin `Markdown<=3.0` as the Markdown extension API has changed.
 
 Version 0.6
 ~~~~~~~~~~~

--- a/flask_flatpages/__init__.py
+++ b/flask_flatpages/__init__.py
@@ -15,6 +15,6 @@ from .page import Page  # noqa
 from .utils import pygmented_markdown, pygments_style_defs  # noqa
 
 
-__author__ = 'Simon Sapin, Igor Davydenko'
+__author__ = 'Simon Sapin, Igor Davydenko, Padraic Calpin'
 __license__ = 'BSD License'
-__version__ = '0.7.0.dev0'
+__version__ = '0.6.1'

--- a/flask_flatpages/flatpages.py
+++ b/flask_flatpages/flatpages.py
@@ -7,10 +7,10 @@ Flatpages extension.
 
 """
 
-from inspect import getargspec
-from itertools import takewhile
 import operator
 import os
+from inspect import getargspec
+from itertools import takewhile
 
 from flask import abort
 from werkzeug.utils import cached_property, import_string

--- a/flask_flatpages/flatpages.py
+++ b/flask_flatpages/flatpages.py
@@ -7,11 +7,10 @@ Flatpages extension.
 
 """
 
-import operator
-import os
-
 from inspect import getargspec
 from itertools import takewhile
+import operator
+import os
 
 from flask import abort
 from werkzeug.utils import cached_property, import_string
@@ -22,7 +21,6 @@ from .utils import force_unicode, pygmented_markdown
 
 
 class FlatPages(object):
-
     """A collection of :class:`Page` objects."""
 
     #: Default configuration for FlatPages extension
@@ -104,7 +102,7 @@ class FlatPages(object):
 
     def init_app(self, app):
         """
-        Used to initialize an application, useful for passing an app later and
+        Use to initialize an application, useful for passing an app later and
         app factory patterns.
 
         :param app: your application
@@ -279,7 +277,7 @@ class FlatPages(object):
 
         """
         def wrapper(page):
-            """Simple wrapper to inspect the HTML renderer function and pass
+            """Use to wrap HTML renderer function and pass
             arguments to it based on the number of arguments.
 
             * 1 argument -> page body

--- a/flask_flatpages/flatpages.py
+++ b/flask_flatpages/flatpages.py
@@ -224,9 +224,14 @@ class FlatPages(object):
                 'a sequence, got {0} instead: {1}'.
                 format(type(extension).__name__, extension)
             )
-
-        return dict([(path, self._load_file(path, full_name))
-                     for path, full_name in _walker()])
+        pages = {}
+        for path, full_name in _walker():
+            if path in pages:
+                raise ValueError(
+                    'Multiple pages found which correspond to the same path. '
+                    'This error can arise when using multiple extensions.')
+            pages[path] = self._load_file(path, full_name)
+        return pages
 
     def _parse(self, content, path):
         """Parse a flatpage file, i.e. read and parse its meta data and body.

--- a/flask_flatpages/page.py
+++ b/flask_flatpages/page.py
@@ -7,8 +7,8 @@ Define flatpage instance.
 
 """
 
-from werkzeug.utils import cached_property
 import yaml
+from werkzeug.utils import cached_property
 
 
 class Page(object):

--- a/flask_flatpages/page.py
+++ b/flask_flatpages/page.py
@@ -7,13 +7,11 @@ Define flatpage instance.
 
 """
 
-import yaml
-
 from werkzeug.utils import cached_property
+import yaml
 
 
 class Page(object):
-
     """Simple class to store all necessary information about a flatpage.
 
     Main purpose is to render the page's content with a ``html_renderer``
@@ -62,7 +60,10 @@ class Page(object):
 
     @cached_property
     def meta(self):
-        """A dict of metadata parsed as YAML from the header of the file."""
+        """
+        Store a dict of metadata parsed as YAML
+        from the header of the file.
+        """
         meta = yaml.safe_load(self._meta)
         # YAML documents can be any type but we want a dict
         # eg. yaml.safe_load('') -> None

--- a/setup.py
+++ b/setup.py
@@ -28,9 +28,9 @@ setup(
     zip_safe=False,
     platforms='any',
     install_requires=[
-        'Flask>=0.8',
+        'Flask>=1.0',
         'PyYAML>=3.10',
-        'Markdown>=2.3.1'
+        'Markdown>=2.6.11'
     ],
     tests_require=['Pygments>=1.6'],
     extras_require={

--- a/setup.py
+++ b/setup.py
@@ -30,7 +30,7 @@ setup(
     install_requires=[
         'Flask>=1.0',
         'PyYAML>=3.10',
-        'Markdown==2.6.11'
+        'Markdown<3.0'
     ],
     tests_require=['Pygments>=1.6'],
     extras_require={

--- a/setup.py
+++ b/setup.py
@@ -30,7 +30,7 @@ setup(
     install_requires=[
         'Flask>=1.0',
         'PyYAML>=3.10',
-        'Markdown>=2.6.11'
+        'Markdown==2.6.11'
     ],
     tests_require=['Pygments>=1.6'],
     extras_require={
@@ -48,8 +48,9 @@ setup(
         'Programming Language :: Python :: 2.6',
         'Programming Language :: Python :: 2.7',
         'Programming Language :: Python :: 3',
-        'Programming Language :: Python :: 3.3',
         'Programming Language :: Python :: 3.4',
+        'Programming Language :: Python :: 3.5',
+        'Programming Language :: Python :: 3.6',
         'Programming Language :: Python :: Implementation :: PyPy',
     ]
 )

--- a/tests/test_flask_flatpages.py
+++ b/tests/test_flask_flatpages.py
@@ -170,6 +170,16 @@ class TestFlatPages(unittest.TestCase):
     def test_extension_tuple(self):
         self.test_extension_sequence(('.html', '.txt'))
 
+    def test_catch_conflicting_paths(self):
+        app = Flask(__name__)
+        app.config['FLATPAGES_EXTENSION'] = ['.html', '.txt']
+        with temp_pages(app) as pages:
+            original_file = os.path.join(pages.root, 'hello.html')
+            target_file = os.path.join(pages.root, 'hello.txt')
+            shutil.copyfile(original_file, target_file)
+            pages.reload()
+            self.assertRaises(ValueError, pages.get, 'hello')
+
     def test_get(self):
         pages = FlatPages(Flask(__name__))
         self.assertEqual(pages.get('foo/bar').path, 'foo/bar')

--- a/tests/test_flask_flatpages.py
+++ b/tests/test_flask_flatpages.py
@@ -18,7 +18,7 @@ import unittest
 from contextlib import contextmanager
 
 from flask import Flask
-from flask.ext.flatpages import FlatPages, compat, pygments_style_defs
+from flask_flatpages import FlatPages, compat, pygments_style_defs
 from werkzeug.exceptions import NotFound
 
 from .test_temp_directory import temp_directory

--- a/tests/test_markdown_extensions.py
+++ b/tests/test_markdown_extensions.py
@@ -68,7 +68,8 @@ class TestMarkdownExtensions(unittest.TestCase):
             '<h2 id="paragraph-header">Paragraph Header</h2>\n'
             '<p>Text</p>'
         )
-        codehilite = pages.get('codehilite') #Test codehilite also loaded
+        #Test codehilite also loaded
+        codehilite = pages.get('codehilite')
         self.assertEqual(
             codehilite.html,
             '<div class="codehilite"><pre><span></span><span class="k">print</span>'
@@ -77,18 +78,10 @@ class TestMarkdownExtensions(unittest.TestCase):
         )
 
     def test_codehilite_linenums_disabled(self):
-        #Test implicitly disabled
+        #Test explicity disabled
         app = Flask(__name__)
         app.config['FLATPAGES_MARKDOWN_EXTENSIONS'] = ['codehilite']
         pages = FlatPages(app)
-        codehilite = pages.get('codehilite')
-        self.assertEqual(
-            codehilite.html,
-            '<div class="codehilite"><pre><span></span><span class="k">print</span>'
-            '<span class="p">(</span><span class="s1">&#39;Hello, world!&#39;'
-            '</span><span class="p">)</span>\n</pre></div>'
-        )
-        #Test explicity disabled
         pages.app.config['FLATPAGES_MARKDOWN_EXTENSIONS'] = [
             'codehilite(linenums=False)'
         ]

--- a/tests/test_markdown_extensions.py
+++ b/tests/test_markdown_extensions.py
@@ -47,7 +47,14 @@ class TestMarkdownExtensions(unittest.TestCase):
             hello.html,
             u'<h1>Page Header</h1>\n<h2>Paragraph Header</h2>\n<p>Text</p>'
         )
-
+        codehilite = pages.get('codehilite') #Test codehilite loaded by default
+                                             #by pygmented_markdown
+        self.assertEqual(
+            codehilite.html,
+            '<div class="codehilite"><pre><span></span><span class="k">print</span>'
+            '<span class="p">(</span><span class="s1">&#39;Hello, world!&#39;'
+            '</span><span class="p">)</span>\n</pre></div>'
+        )
         pages.app.config['FLATPAGES_MARKDOWN_EXTENSIONS'] = [
             'codehilite', 'headerid'
         ]
@@ -61,19 +68,37 @@ class TestMarkdownExtensions(unittest.TestCase):
             '<h2 id="paragraph-header">Paragraph Header</h2>\n'
             '<p>Text</p>'
         )
+        codehilite = pages.get('codehilite') #Test codehilite also loaded
+        self.assertEqual(
+            codehilite.html,
+            '<div class="codehilite"><pre><span></span><span class="k">print</span>'
+            '<span class="p">(</span><span class="s1">&#39;Hello, world!&#39;'
+            '</span><span class="p">)</span>\n</pre></div>'
+        )
 
     def test_codehilite_linenums_disabled(self):
+        #Test implicitly disabled
         app = Flask(__name__)
-        app.config['FLATPAGES_MARKDOWN_EXTENSIONS'] = [
-            'codehilite(linenums=False)'
-        ]
+        app.config['FLATPAGES_MARKDOWN_EXTENSIONS'] = ['codehilite']
         pages = FlatPages(app)
-
         codehilite = pages.get('codehilite')
         self.assertEqual(
             codehilite.html,
-            '<div class="codehilite"><pre><span class="k">print</span>'
-            '<span class="p">(</span><span class="s">&#39;Hello, world!&#39;'
+            '<div class="codehilite"><pre><span></span><span class="k">print</span>'
+            '<span class="p">(</span><span class="s1">&#39;Hello, world!&#39;'
+            '</span><span class="p">)</span>\n</pre></div>'
+        )
+        #Test explicity disabled
+        pages.app.config['FLATPAGES_MARKDOWN_EXTENSIONS'] = [
+            'codehilite(linenums=False)'
+        ]
+        pages.reload()
+        pages._file_cache = {}
+        codehilite = pages.get('codehilite')
+        self.assertEqual(
+            codehilite.html,
+            '<div class="codehilite"><pre><span></span><span class="k">print</span>'
+            '<span class="p">(</span><span class="s1">&#39;Hello, world!&#39;'
             '</span><span class="p">)</span>\n</pre></div>'
         )
 
@@ -89,8 +114,8 @@ class TestMarkdownExtensions(unittest.TestCase):
             codehilite.html,
             '<table class="codehilitetable"><tr><td class="linenos">'
             '<div class="linenodiv"><pre>1</pre></div></td><td class="code">'
-            '<div class="codehilite"><pre><span class="k">print</span>'
-            '<span class="p">(</span><span class="s">&#39;Hello, world!&#39;'
+            '<div class="codehilite"><pre><span></span><span class="k">print</span>'
+            '<span class="p">(</span><span class="s1">&#39;Hello, world!&#39;'
             '</span><span class="p">)</span>\n</pre></div>\n</td></tr></table>'
         )
 

--- a/tox.ini
+++ b/tox.ini
@@ -32,6 +32,6 @@ deps =
 setenv =
   PYTHONPATH=.
 commands =
-  flake8 --statistics flask_flatpages/
+  flake8 --statistics ./flask_flatpages/
   nosetests -v -w tests/ --with-coverage --cover-branches --cover-package=flask_flatpages \
   {posargs:--cover-html --cover-html-dir=/tmp/flask-flatpages-coverage}

--- a/tox.ini
+++ b/tox.ini
@@ -6,35 +6,29 @@ max-complexity = 20
 
 [tox]
 envlist =
-  py{26,27,py}-flask{08,09,10},py33-flask010,py34-flask010
+  py{27}-flask{10,102},py{34}-flask{10,102},py{35}-flask{10,102},py{36}-flask{10,102}
 
 [testenv]
 deps =
-  flask08: Flask==0.8
-  flask09: Flask==0.9
-  flask010: Flask==0.10.1
-  Jinja2==2.7.3
-  py26: Markdown==2.3.1
-  py27: Markdown==2.6.2
-  py33: Markdown==2.6.2
-  py34: Markdown==2.6.2
-  pypy: Markdown==2.6.2
-  MarkupSafe==0.23
-  PyYAML==3.11
-  Pygments==2.0.2
-  Werkzeug==0.10.4
-  coverage==3.7.1
-  docutils==0.12
-  flake8==2.3.0
-  flake8-docstrings==0.2.1.post1
-  flake8-import-order==0.5.3
-  itsdangerous==0.24
-  mccabe==0.3.0
-  nose==1.3.6
-  pep257==0.5.0
-  pep8==1.6.2
-  pep8-naming==0.2.2
-  pyflakes==0.8.1
+  flask10: Flask==1.0
+  flask102: Flask==1.0.2
+  Werkzeug>=0.14
+  Jinja2>=2.10
+  itsdangerous>=0.24
+  click>=5.1
+  PyYAML>=3.10
+  Pygments>=2.0.2
+  coverage>=3.7.1
+  docutils>=0.12
+  flake8>=2.3.0
+  flake8-docstrings>=0.2.1.post1
+  flake8-import-order>=0.5.3
+  mccabe>=0.3.0
+  nose>=1.3.7
+  pep257>=0.5.0
+  pep8>=1.6.2
+  pep8-naming>=0.2.2
+  pyflakes>=0.8.1
 setenv =
   PYTHONPATH=.
 commands =

--- a/tox.ini
+++ b/tox.ini
@@ -18,7 +18,7 @@ deps =
   click>=5.1
   PyYAML>=3.10
   Pygments>=2.0.2
-  Markdown>=2.6.11
+  Markdown==2.6.11
   coverage>=3.7.1
   docutils>=0.12
   flake8>=2.3.0

--- a/tox.ini
+++ b/tox.ini
@@ -18,6 +18,7 @@ deps =
   click>=5.1
   PyYAML>=3.10
   Pygments>=2.0.2
+  Markdown>=2.6.11
   coverage>=3.7.1
   docutils>=0.12
   flake8>=2.3.0

--- a/tox.ini
+++ b/tox.ini
@@ -6,19 +6,19 @@ max-complexity = 20
 
 [tox]
 envlist =
-  py{27}-flask{10,102},py{34}-flask{10,102},py{35}-flask{10,102},py{36}-flask{10,102}
+  py{27}-flask{10,latest},py{34}-flask{10,latest},py{35}-flask{10,latest},py{36}-flask{10,latest},py{37}-flask{10,latest}
 
 [testenv]
 deps =
   flask10: Flask==1.0
-  flask102: Flask==1.0.2
+  flasklatest: Flask>=1.0
   Werkzeug>=0.14
   Jinja2>=2.10
   itsdangerous>=0.24
   click>=5.1
   PyYAML>=3.10
   Pygments>=2.0.2
-  Markdown==2.6.11
+  Markdown<3.0
   coverage>=3.7.1
   docutils>=0.12
   flake8>=2.3.0
@@ -33,6 +33,6 @@ deps =
 setenv =
   PYTHONPATH=.
 commands =
-  flake8 --statistics ./flask_flatpages/
+  flake8 --statistics flask_flatpages/ --import-order-style smarkets
   nosetests -v -w tests/ --with-coverage --cover-branches --cover-package=flask_flatpages \
   {posargs:--cover-html --cover-html-dir=/tmp/flask-flatpages-coverage}


### PR DESCRIPTION
Flask is now 1.0, and the maintained versions of python have also changed. This updates the project dependencies and testing to reflect the latest versions of Flask, Markdown and Pygments on Python 2.7 and 3.4+. I also made small edits to make the code pass flake8 tests.

This badge shows the results of the tests from my personal fork. 
[![Build Status](https://travis-ci.org/padraic-padraic/Flask-FlatPages.svg?branch=master)](https://travis-ci.org/padraic-padraic/Flask-FlatPages)