### PR TITLE
Fix #77: replace getargspec if possible

### DIFF
--- a/flask_flatpages/flatpages.py
+++ b/flask_flatpages/flatpages.py
@@ -9,9 +9,13 @@ Flatpages extension.
 
 import operator
 import os
-from inspect import getargspec
 from itertools import takewhile
 
+import six
+if six.PY3:
+    from inspect import getfullargspec
+else:
+    from inspect import getargspec as getfullargspec
 from flask import abort
 from werkzeug.utils import cached_property, import_string
 
@@ -304,7 +308,7 @@ class FlatPages(object):
             body = page.body
 
             try:
-                args_length = len(getargspec(html_renderer).args)
+                args_length = len(getfullargspec(html_renderer).args)
             except TypeError:
                 return html_renderer(body)
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -52,6 +52,7 @@ install_requires =
     PyYAML==3.12; python_version=="3.4"
     PyYAML>3.12; python_version!="3.4"
     Jinja2>=2.10.2
+    six; python_version!="3.4"
 python_requires=>=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*
 zip_safe = False
 


### PR DESCRIPTION
This uses `getfullargspec` instead of `getargspec` if running with
python3. For python2 it sticks to `getargspec`.