### PR TITLE
Improved YAML Frontmatter

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -140,8 +140,20 @@ are optional.
     `See the Markdown 3 documentation for more details <https://python-markdown.github.io/reference/#extension_configs>`_
 
 ``FLATPAGES_AUTO_RELOAD``
-    Wether to reload pages at each request. See :ref:`laziness-and-caching`
+    Whether to reload pages at each request. See :ref:`laziness-and-caching`
     for more details.  The default is to reload in ``DEBUG`` mode only.
+
+``FLATPAGES_LEGACY_META_PARSER``
+    .. versionadded:: 0.8
+
+    Controls whether to use the newer parser based on tokenising metadata
+    with libyaml.
+
+    Setting this to true reverts to the simpler method of parsing metadata
+    used in versions <0.8, which requires the metadata block be terminated
+    by a newline, or else if there's no metadata that a leading newline be
+    present. Intended to provide a fallback in case of bugs with the newer
+    parser.
 
 Please note that multiple FlatPages instances can be configured by using a
 name for the FlatPages instance at initializaton time:
@@ -167,7 +179,7 @@ relative to the pages root, and excluding the extension. For example, for
 an app in ``C:\myapp`` with the default configuration, the path for the
 ``C:\myapp\pages\lorem\ipsum.html`` is ``lorem/ipsum``.
 
-Each file is made of a `YAML`_ mapping of metadata, a blank line, and the
+Each file is made of a `YAML`_ mapping of metadata, and the
 page body::
 
     title: Hello
@@ -196,6 +208,59 @@ and in templates:
 .. code-block:: html+jinja
 
     <link rel="stylesheet" href="{{ url_for('pygments_css') }}">
+
+Delimiting YAML Metadata
+~~~~~~~~~~~~~~~~~~~~~~~~
+
+.. versionadded:: 0.8
+
+In previous versions, YAML metadata was terminated by a newline. This meant it
+was impossible to use multi-line strings in the metadata, or worse that if
+your page had no metadata at all it needed to start with an empty line.
+
+Starting with v0.8, YAML can now be delimited in 'Jekyll' style, by wrapping
+it with ``---``::
+
+    ---
+    title: Hello World
+    author: J.L Coolman
+    ---
+    Hello, world!
+
+Or using YAML 'end document' specifiers like::
+
+    ---
+    title: Hello Again
+    author: J.L Coolman
+    ...
+    Hello, world!
+
+Or by terminating with a newline, in a backwards compatible way.
+
+In all cases, the leading ``---`` is optional.
+
+With this change, it's now possible to have pages with no-metadata
+by starting them with::
+
+    ---
+    ---
+    Hello, this is my page
+
+Or::
+
+    ---
+    ...
+    Hello, this is a page too
+
+Or even just launching in to the body::
+    
+    Hello, this is also a page!
+
+.. warning:: 
+    If you want to use multiline strings in metadatia you **must** use
+    a start and end delimiter, or else the parser may cut the metadata
+    at the first blank line.
+
 
 Using custom Markdown extensions
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/flask_flatpages/flatpages.py
+++ b/flask_flatpages/flatpages.py
@@ -1,12 +1,25 @@
 """Flatpages extension."""
-
 import operator
 import os
+from io import StringIO
 from itertools import takewhile
+
 
 import six
 from flask import abort
 from werkzeug.utils import cached_property, import_string
+from yaml import (
+    BlockMappingStartToken,
+    BlockSequenceStartToken,
+    DocumentEndToken,
+    DocumentStartToken,
+    FlowMappingStartToken,
+    FlowSequenceStartToken,
+    KeyToken,
+    SafeLoader,
+    ScalarToken
+)
+
 
 from .page import Page
 from .utils import force_unicode, pygmented_markdown
@@ -16,6 +29,28 @@ if six.PY3:
     from inspect import getfullargspec
 else:
     from inspect import getargspec as getfullargspec
+
+
+START_TOKENS = (BlockMappingStartToken, BlockSequenceStartToken,
+                DocumentStartToken, FlowMappingStartToken,
+                FlowSequenceStartToken, KeyToken)
+
+
+def _check_newline_token(token):
+    return (
+        isinstance(token, ScalarToken) and
+        token.style is None and
+        '\n' in token.value
+    )
+
+
+def _check_continue_parsing_tokens(token):
+    return not (
+        isinstance(
+            token,
+            (DocumentStartToken, DocumentEndToken)
+        ) or token is None
+    )
 
 
 class FlatPages(object):
@@ -31,7 +66,8 @@ class FlatPages(object):
         ('extension_configs', {}),
         ('auto_reload', 'if debug'),
         ('case_insensitive', False),
-        ('instance_relative', False)
+        ('instance_relative', False),
+        ('legacy_frontmatter', False)
     )
 
     def __init__(self, app=None, name=None):
@@ -249,18 +285,67 @@ class FlatPages(object):
             pages[path] = self._load_file(path, full_name, rel_path)
         return pages
 
-    def _parse(self, content, path, rel_path):
-        """Parse a flatpage file, i.e. read and parse its meta data and body.
-
-        :return: initialized :class:`Page` instance.
-        """
+    def _legacy_parser(self, content):
         lines = iter(content.split('\n'))
-
         # Read lines until an empty line is encountered.
         meta = '\n'.join(takewhile(operator.methodcaller('strip'), lines))
         # The rest is the content. `lines` is an iterator so it continues
         # where `itertools.takewhile` left it.
         content = '\n'.join(lines)
+        return meta, content
+
+    def _libyaml_parser(self, content):
+        yaml_loader = SafeLoader(StringIO(content))
+        yaml_loader.get_token()  # Get stream start token
+        token = yaml_loader.get_token()
+        if not isinstance(token, START_TOKENS):
+            meta = ''
+            content = content.lstrip('\n')
+        else:
+            lines = content.split('\n')
+            if isinstance(token, DocumentStartToken):
+                token = yaml_loader.get_token()
+            newline_token = None
+            while _check_continue_parsing_tokens(token):
+                try:
+                    token = yaml_loader.get_token()
+                    if (
+                        _check_newline_token(token) and
+                        newline_token is None
+                    ):
+                        newline_token = token
+                except Exception:
+                    break
+            if token is None and newline_token is None:
+                meta = content
+                content = ''
+            else:
+                if token is not None:
+                    meta_end_line = token.end_mark.line + 1
+                else:
+                    meta_end_line = newline_token.start_mark.line
+                    meta_end_line += lines[meta_end_line:].index('')
+                meta = '\n'.join(lines[:meta_end_line])
+                content = '\n'.join(lines[meta_end_line:]).lstrip('\n')
+        return meta, content
+
+    def _parse(self, content, path, rel_path):
+        """Parse a flatpage file, i.e. read and parse its meta data and body.
+
+        :return: initialized :class:`Page` instance.
+        """
+        if self.config('LEGACY_FRONTMATTER'):
+            meta, content = self._legacy_parser(content)
+        else:
+            meta, content = self._libyaml_parser(content)
+
+        # lines = iter(content.split('\n'))
+
+        # # Read lines until an empty line is encountered.
+        # meta = '\n'.join(takewhile(operator.methodcaller('strip'), lines))
+        # # The rest is the content. `lines` is an iterator so it continues
+        # # where `itertools.takewhile` left it.
+        # content = '\n'.join(lines)
 
         # Now we ready to get HTML renderer function
         html_renderer = self.config('html_renderer')

--- a/flask_flatpages/flatpages.py
+++ b/flask_flatpages/flatpages.py
@@ -1,8 +1,6 @@
 """Flatpages extension."""
-import operator
 import os
 from io import StringIO
-from itertools import takewhile
 
 
 import six

--- a/flask_flatpages/flatpages.py
+++ b/flask_flatpages/flatpages.py
@@ -1,7 +1,6 @@
 """Flatpages extension."""
 import operator
 import os
-from io import StringIO
 from itertools import takewhile
 
 
@@ -27,8 +26,10 @@ from .utils import force_unicode, pygmented_markdown
 
 if six.PY3:
     from inspect import getfullargspec
+    from io import StringIO
 else:
     from inspect import getargspec as getfullargspec
+    from StringIO import StringIO
 
 
 START_TOKENS = (BlockMappingStartToken, BlockSequenceStartToken,
@@ -286,6 +287,8 @@ class FlatPages(object):
         return pages
 
     def _libyaml_parser(self, content):
+        if not six.PY3:
+            content = force_unicode(content)
         yaml_loader = SafeLoader(StringIO(content))
         yaml_loader.get_token()  # Get stream start token
         token = yaml_loader.get_token()
@@ -318,6 +321,8 @@ class FlatPages(object):
                     meta_end_line += lines[meta_end_line:].index('')
                 meta = '\n'.join(lines[:meta_end_line])
                 content = '\n'.join(lines[meta_end_line:]).lstrip('\n')
+        if not six.PY3:
+            return force_unicode(meta), force_unicode(content)
         return meta, content
 
     def _legacy_parser(self, content):

--- a/flask_flatpages/flatpages.py
+++ b/flask_flatpages/flatpages.py
@@ -67,7 +67,6 @@ class FlatPages(object):
         ('auto_reload', 'if debug'),
         ('case_insensitive', False),
         ('instance_relative', False),
-        ('legacy_frontmatter', False)
     )
 
     def __init__(self, app=None, name=None):
@@ -285,15 +284,6 @@ class FlatPages(object):
             pages[path] = self._load_file(path, full_name, rel_path)
         return pages
 
-    def _legacy_parser(self, content):
-        lines = iter(content.split('\n'))
-        # Read lines until an empty line is encountered.
-        meta = '\n'.join(takewhile(operator.methodcaller('strip'), lines))
-        # The rest is the content. `lines` is an iterator so it continues
-        # where `itertools.takewhile` left it.
-        content = '\n'.join(lines)
-        return meta, content
-
     def _libyaml_parser(self, content):
         yaml_loader = SafeLoader(StringIO(content))
         yaml_loader.get_token()  # Get stream start token
@@ -334,18 +324,7 @@ class FlatPages(object):
 
         :return: initialized :class:`Page` instance.
         """
-        if self.config('LEGACY_FRONTMATTER'):
-            meta, content = self._legacy_parser(content)
-        else:
-            meta, content = self._libyaml_parser(content)
-
-        # lines = iter(content.split('\n'))
-
-        # # Read lines until an empty line is encountered.
-        # meta = '\n'.join(takewhile(operator.methodcaller('strip'), lines))
-        # # The rest is the content. `lines` is an iterator so it continues
-        # # where `itertools.takewhile` left it.
-        # content = '\n'.join(lines)
+        meta, content = self._libyaml_parser(content)
 
         # Now we ready to get HTML renderer function
         html_renderer = self.config('html_renderer')

--- a/flask_flatpages/page.py
+++ b/flask_flatpages/page.py
@@ -1,4 +1,6 @@
 """Define flatpage instance."""
+from io import StringIO
+
 
 import yaml
 from werkzeug.utils import cached_property
@@ -58,7 +60,11 @@ class Page(object):
     @cached_property
     def meta(self):
         """Store a dict of metadata parsed from the YAML header of the file."""
-        meta = yaml.safe_load(self._meta)
+        # meta = yaml.safe_load(self._meta)
+        meta = {}
+        for doc in yaml.safe_load_all(StringIO(self._meta)):
+            if doc is not None:
+                meta.update(doc)
         # YAML documents can be any type but we want a dict
         # eg. yaml.safe_load('') -> None
         #     yaml.safe_load('- 1\n- a') -> [1, 'a']

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,6 +13,7 @@ requires=
 
 [testenv]
 deps =
+  py27-pygments{yes,no}: mock==3.0.5
   py{27,36,37,38,39,310}-pygmentsyes: Pygments>=2.0.2
   coverage>=3.7.1
   docutils>=0.12

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,7 +13,7 @@ requires=
 
 [testenv]
 deps =
-  py{27,36,37,38,30}-pygmentsyes: Pygments>=2.0.2
+  py{27,36,37,38,39,310}-pygmentsyes: Pygments>=2.0.2
   coverage>=3.7.1
   docutils>=0.12
   flake8>=2.3.0

--- a/tests/pages/meta_styles/jekyll_style.html
+++ b/tests/pages/meta_styles/jekyll_style.html
@@ -1,0 +1,5 @@
+---
+hello: world
+---
+
+Foo

--- a/tests/pages/meta_styles/multi_line.html
+++ b/tests/pages/meta_styles/multi_line.html
@@ -1,0 +1,7 @@
+---
+multi_line_string: |
+  Hello, world!
+
+  This is a multi_line_string
+---
+Foo

--- a/tests/pages/meta_styles/no_meta.html
+++ b/tests/pages/meta_styles/no_meta.html
@@ -1,0 +1,1 @@
+Hello, there's no metadata here.

--- a/tests/pages/meta_styles/yaml_style.html
+++ b/tests/pages/meta_styles/yaml_style.html
@@ -1,0 +1,5 @@
+---
+hello: world
+...
+
+Foo

--- a/tests/test_flask_flatpages.py
+++ b/tests/test_flask_flatpages.py
@@ -169,6 +169,10 @@ class TestFlatPages(unittest.TestCase):
                  'foo/lorem/ipsum',
                  'headerid',
                  'hello',
+                 'meta_styles/yaml_style',
+                 'meta_styles/jekyll_style',
+                 'meta_styles/multi_line',
+                 'meta_styles/no_meta',
                  'not_a_page',
                  'toc'])
         )
@@ -197,10 +201,7 @@ class TestFlatPages(unittest.TestCase):
             original_file = os.path.join(pages.root, 'hello.html')
             upper_file = os.path.join(pages.root, 'Hello.html')
             txt_file = os.path.join(pages.root, 'hello.txt')
-            print(original_file)
-            print(upper_file)
             shutil.move(original_file, upper_file)
-            print(os.listdir(pages.root))
             pages.reload()
             self.assertEqual(
                 set(page.path for page in pages),
@@ -212,6 +213,10 @@ class TestFlatPages(unittest.TestCase):
                      'foo/lorem/ipsum',
                      'headerid',
                      'hello',
+                     'meta_styles/yaml_style',
+                     'meta_styles/jekyll_style',
+                     'meta_styles/multi_line',
+                     'meta_styles/no_meta',
                      'not_a_page',
                      'toc'])
             )
@@ -241,6 +246,10 @@ class TestFlatPages(unittest.TestCase):
                  'foo/lorem/ipsum',
                  'headerid',
                  'hello',
+                 'meta_styles/yaml_style',
+                 'meta_styles/jekyll_style',
+                 'meta_styles/multi_line',
+                 'meta_styles/no_meta',
                  'toc'])
         )
 
@@ -423,6 +432,10 @@ class TestFlatPages(unittest.TestCase):
                      'foo/lorem/ipsum',
                      'headerid',
                      'hello',
+                     'meta_styles/yaml_style',
+                     'meta_styles/jekyll_style',
+                     'meta_styles/multi_line',
+                     'meta_styles/no_meta',
                      'toc'])
             )
 
@@ -438,6 +451,10 @@ class TestFlatPages(unittest.TestCase):
                      'foo/bar',
                      'headerid',
                      'hello',
+                     'meta_styles/yaml_style',
+                     'meta_styles/jekyll_style',
+                     'meta_styles/multi_line',
+                     'meta_styles/no_meta',
                      'toc',
                      u'Unïcôdé']))
 
@@ -461,3 +478,69 @@ class TestFlatPages(unittest.TestCase):
                                            tzinfo=utc))
         self.assertEqual(foo['versions'], [3.14, 42])
         self.assertRaises(KeyError, lambda: foo['nonexistent'])
+
+    def test_no_meta(self):
+        app = Flask(__name__)
+        with temp_pages(app) as pages:
+            no_meta = pages.get('meta_styles/no_meta')
+            self.assertEqual(no_meta.meta, {})
+            filename = os.path.join(pages.root, 'meta_styles', 'no_meta.html')
+            with open(filename, 'w') as f_:
+                f_.write("\n Hello, there's no metadata here.")
+            pages.reload()
+            no_meta = pages.get('meta_styles/no_meta')
+            self.assertEqual(no_meta.meta, {})
+            with open(filename, 'w') as f_:
+                f_.write("---\n---\nHello, there's no metadata here.")
+            pages.reload()
+            no_meta = pages.get('meta_styles/no_meta')
+            self.assertEqual(no_meta.meta, {})
+            with open(filename, 'w') as f_:
+                f_.write("---\n...\nHello, there's no metadata here.")
+            pages.reload()
+            no_meta = pages.get('meta_styles/no_meta')
+            self.assertEqual(no_meta.meta, {})
+            with open(filename, 'w') as f_:
+                f_.write("#Hello, there's no metadata here.")
+            pages.reload()
+            no_meta = pages.get('meta_styles/no_meta')
+            self.assertEqual(no_meta.meta, {})
+
+    def test_jekyll_style_meta(self):
+        app = Flask(__name__)
+        with temp_pages(app) as pages:
+            jekyll_style = pages.get('meta_styles/jekyll_style')
+            self.assertEqual(jekyll_style.meta, {'hello': 'world'})
+            self.assertEqual(jekyll_style.body, 'Foo')
+            filename = os.path.join(pages.root, 'meta_styles', 'jekyll_style.html')
+            with open(filename, 'r') as f_:
+                lines = f_.readlines()
+            with open(filename, 'w') as f_:
+                f_.write('\n'.join(lines[1:]))
+            pages.reload()
+            jekyll_style = pages.get('meta_styles/jekyll_style')
+            self.assertEqual(jekyll_style.meta, {'hello': 'world'})
+            self.assertEqual(jekyll_style.body, 'Foo')
+
+    def test_yaml_style_meta(self):
+        app = Flask(__name__)
+        with temp_pages(app) as pages:
+            yaml_style = pages.get('meta_styles/yaml_style')
+            self.assertEqual(yaml_style.meta, {'hello': 'world'})
+            self.assertEqual(yaml_style.body, 'Foo')
+            filename = os.path.join(pages.root, 'meta_styles', 'yaml_style.html')
+            with open(filename, 'r') as f_:
+                lines = f_.readlines()
+            with open(filename, 'w') as f_:
+                f_.write('\n'.join(lines[1:]))
+            pages.reload()
+            yaml_style = pages.get('meta_styles/yaml_style')
+            self.assertEqual(yaml_style.meta, {'hello': 'world'})
+            self.assertEqual(yaml_style.body, 'Foo')
+
+    def test_multi_line(self):
+        pages = FlatPages(Flask(__name__))
+        multi_line = pages.get('meta_styles/multi_line')
+        self.assertEqual(multi_line.body, 'Foo')
+        self.assertIn('multi_line_string', multi_line.meta)
+        self.assertIn('\n', multi_line.meta['multi_line_string'])


### PR DESCRIPTION
This PR supercedes #64, and additionally closes #59. 

The main thrust of the PR is to tweak the metadata parser to use `pyyaml` to extract the valid metadata from the file. This allows us to:
+ Terminate metadata with a newline in a backwards-compatible way (unless we want multi-line strings, caveat to be added to the docs)
+ Delimit metadata with `---`...`---` or `---`...`...`.
+ Include no metadata at all, either by starting a document with `---\n---`, `---\n...`, `\n`, or just starting to supply valid Markdown/HTML.