### PR TITLE
drop usage of "six"

### DIFF
--- a/flask_flatpages/utils.py
+++ b/flask_flatpages/utils.py
@@ -1,15 +1,11 @@
 """Utility functions to render Markdown text to HTML."""
 
 import markdown
-import six
 from markdown.extensions import codehilite
 
 from .imports import PygmentsHtmlFormatter
 
-if six.PY3:
-    from io import StringIO
-else:
-    from StringIO import StringIO
+from io import StringIO
 
 
 class NamedStringIO(StringIO, object):
@@ -23,16 +19,13 @@ class NamedStringIO(StringIO, object):
         :param name: The name to attach to the stream. Will
             be consumed in e.g. ReaderErrors raised by pyyaml.
         """
-        if not six.PY3:
-            super(NamedStringIO, self).__init__(content)
-        else:
-            super().__init__(content)
+        super().__init__(content)
         self.name = name
 
 
 def force_unicode(value, encoding="utf-8", errors="strict"):
     """Convert bytes or any other Python instance to string."""
-    if isinstance(value, six.text_type):
+    if isinstance(value, str):
         return value
     return value.decode(encoding, errors)
 
@@ -68,14 +61,14 @@ def pygmented_markdown(text, flatpages=None):
 
         for extension in original_extensions:
             if (
-                isinstance(extension, six.string_types)
+                isinstance(extension, str)
                 and "codehilite" in extension
             ):
                 continue
             elif isinstance(extension, codehilite.CodeHiliteExtension):
                 continue
             extensions.append(extension)
-            if isinstance(extension, six.string_types):
+            if isinstance(extension, str):
                 if extension in original_config:
                     extension_configs[extension] = original_config[extension]
     elif not extensions:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,6 @@
 [build-system]
 requires = [
-    "setuptools < 45 ; python_version < '3'",
-    "setuptools ; python_version > '2.7'",
+    "setuptools",
     "wheel",
 ]
 build-backend = "setuptools.build_meta"
@@ -26,8 +25,6 @@ classifiers = [
     "Programming Language :: Python",
     "Topic :: Internet :: WWW/HTTP :: Dynamic Content",
     "Topic :: Software Development :: Libraries :: Python Modules",
-    "Programming Language :: Python :: 2",
-    "Programming Language :: Python :: 2.7",
     "Programming Language :: Python :: 3",
     "Programming Language :: Python :: 3.7",
     "Programming Language :: Python :: 3.8",
@@ -37,14 +34,13 @@ classifiers = [
     "Programming Language :: Python :: 3.12",
     "Programming Language :: Python :: 3.13",
 ]
-requires-python = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*, !=3.5.*, !=3.6.*"
+requires-python = ">=3.7"
 dependencies = [
     "Flask > 1.0",
     "Jinja2 >= 2.10.2",
     "Markdown >= 2.5",
     "PyYAML > 5.3.1",
     "pytz; python_version=='2.7'",
-    "six",
 ]
 [project.urls]
 Repository = "https://github.com/Flask-FlatPages/Flask-FlatPages"
@@ -68,8 +64,6 @@ envlist = [
     "docs",
     "lint",
     "fmt",
-    "py27",
-    "py27-pygments",
     "py37",
     "py37-pygments",
     "py38",
@@ -101,9 +95,6 @@ commands = [
         "{posargs}",
     ],
 ]
-
-[tool.tox.env.py27-pygments]
-extras = ["codehilite"]
 
 [tool.tox.env.py37-pygments]
 extras = ["codehilite"]

--- a/tests/test_flask_flatpages.py
+++ b/tests/test_flask_flatpages.py
@@ -17,7 +17,6 @@ import unittest
 from contextlib import contextmanager
 
 
-import six
 import yaml
 import pytest
 from flask import Flask
@@ -27,13 +26,8 @@ from werkzeug.exceptions import NotFound
 
 from .test_temp_directory import temp_directory
 
-if six.PY3:
-    utc = datetime.timezone.utc
-    from unittest.mock import patch
-else:
-    import pytz
-    utc = pytz.utc
-    from mock import patch
+utc = datetime.timezone.utc
+from unittest.mock import patch
 
 
 @contextmanager
@@ -369,7 +363,7 @@ class TestFlatPages(unittest.TestCase):
 
         renderers = filter(None, (
             operator.methodcaller('upper'),
-            'string.upper' if not six.PY3 else None,
+            None,
             body_renderer,
             page_renderer,
             pages_renderer
@@ -601,10 +595,7 @@ class TestFlatPages(unittest.TestCase):
         app = Flask(__name__)
         with temp_pages(app) as pages:
             with open(os.path.join(pages.root, 'bad_file_test.html'), 'w') as f:
-                if six.PY3:
-                    f.write("Hello World \u000B")
-                else:
-                    f.write("\x0b".decode('utf-8'))
+                f.write("Hello World \u000B")
             with pytest.raises(yaml.reader.ReaderError, match=r".*bad_file_test.*") as excinfo:
                 pages.get('bad_file_test')
 

--- a/tests/test_markdown_extensions.py
+++ b/tests/test_markdown_extensions.py
@@ -17,7 +17,6 @@ from flask import Flask
 from flask_flatpages import FlatPages
 from flask_flatpages.imports import PygmentsHtmlFormatter
 from markdown.extensions.toc import TocExtension
-from six import PY3
 
 
 class TestMarkdownExtensions(unittest.TestCase):


### PR DESCRIPTION
Hi,

I'm removing `six` usage of all the packages in Debian.

Please consider this PR.

https://wiki.debian.org/Python3-six-removal